### PR TITLE
I've refactored `run_forex_test_graph.py` to support a scenario-based…

### DIFF
--- a/TradingAgents/run_forex_test_graph.py
+++ b/TradingAgents/run_forex_test_graph.py
@@ -1,97 +1,425 @@
 import datetime
 import sys
 import os
+import time # For simulating delays if needed
+from typing import List, Dict, Any, Optional
 
-# Adjust the Python path to include the TradingAgents directory
-# This allows a script in the root to import modules from the tradingagents package
-# This is a common pattern for test/run scripts located at the project root.
+# Path Adjustments (as before)
 current_dir = os.path.dirname(os.path.abspath(__file__))
-# Assuming the 'tradingagents' package is at the same level as this script,
-# or one level down if this script is in a 'tests' folder, for example.
-# If TradingAgents/ is the project root and contains run_forex_test_graph.py
-# and the package is TradingAgents/tradingagents/, then TradingAgents/ needs to be in path.
-project_root = current_dir # If script is in TradingAgents/
-# project_root = os.path.dirname(current_dir) # If script is in TradingAgents/tests/
+project_root = current_dir
 sys.path.insert(0, project_root)
-
 
 try:
     from tradingagents.graph.forex_trading_graph import ForexTradingGraph
-    from tradingagents.broker_interface.simulated_broker import SimulatedBroker # Import
-    from tradingagents.forex_utils.forex_states import ForexFinalDecision # For type hinting if needed
+    from tradingagents.broker_interface.simulated_broker import SimulatedBroker
+    from tradingagents.forex_utils.forex_states import ForexFinalDecision, OrderSide, OrderType, TimeInForce, Candlestick # For type hints & setup
 except ImportError as e:
-    print(f"ImportError: {e}. Please ensure that the TradingAgents package is correctly structured")
-    print("and that this script is run from a location where 'tradingagents' can be imported.")
+    print(f"ImportError: {e}. Check paths and ensure all modules are created.")
     print(f"Current sys.path includes: {sys.path[0]}")
     sys.exit(1)
 
-def main():
-    print("--- Starting Forex Trading Graph Test Script ---")
+def setup_scenario_broker(
+    initial_capital: float = 10000.0,
+    leverage: int = 100,
+    default_spread_pips: Optional[Dict[str, float]] = None,
+    commission_per_lot: Optional[Dict[str, float]] = None,
+    margin_warning_level: float = 100.0,
+    stop_out_level: float = 50.0
+) -> SimulatedBroker:
 
-    # Instantiate SimulatedBroker
-    sim_broker = SimulatedBroker()
+    # Provide default spread and commission if None is passed
+    spreads = default_spread_pips if default_spread_pips is not None else {"EURUSD": 0.5, "default": 1.0}
+    commissions = commission_per_lot if commission_per_lot is not None else {"EURUSD": 0.0, "default": 0.0}
 
-    # Define sample inputs
-    currency_pair_to_test = "EURUSD"
-    simulated_time_iso = "2023-10-27T10:00:00+00:00" # Fixed dummy ISO time
+    broker = SimulatedBroker(
+        initial_capital=initial_capital,
+        # These params need to be passed to SimulatedBroker's __init__ if it accepts them
+        # Currently, SimulatedBroker __init__ takes only initial_capital.
+        # It sets default_spread_pips and commission_per_lot internally.
+        # For this refactor, we'll update the broker instance directly after creation for these.
+    )
+    broker.leverage = leverage # Assuming leverage can be set like this, or pass in constructor
+    broker.default_spread_pips = spreads
+    broker.commission_per_lot = commissions
+    broker.margin_call_warning_level_pct = margin_warning_level
+    broker.stop_out_level_pct = stop_out_level
+    return broker
 
-    # Update the simulated broker's current time to match the test time
-    # This is important for get_current_price and get_historical_data in the sim broker
-    simulated_dt_obj = datetime.datetime.fromisoformat(simulated_time_iso.replace('Z', '+00:00'))
-    sim_broker.update_current_time(simulated_dt_obj.timestamp())
-
-
-    # Initialize the graph, passing the broker
-    try:
-        forex_graph_instance = ForexTradingGraph(broker=sim_broker) # Pass broker
-    except Exception as e:
-        print(f"Error initializing ForexTradingGraph: {e}")
-        return
-
-    print(f"\nInvoking graph for: {currency_pair_to_test} at {simulated_time_iso}")
-
-    # Invoke the graph
-    try:
-        # The type hint ForexFinalDecision might need to be Optional if invoke_graph can return None on error
-        final_decision_obj: Optional[ForexFinalDecision] = forex_graph_instance.invoke_graph(
-            currency_pair_to_test,
-            simulated_time_iso
-        )
-        # For pretty print, it's fine if it's None, the check `if final_decision_obj:` handles it
-        final_decision = final_decision_obj
-    except Exception as e:
-        print(f"Error invoking ForexTradingGraph: {e}")
-        # Potentially print more detailed traceback if in debug mode
-        import traceback
-        traceback.print_exc()
-        return
-
-    print("\n--- Forex Graph Execution Complete ---")
-
-    if final_decision: # final_decision is now final_decision_obj
-        print("\n=== Final Decision Received ===")
-        # Pretty print the TypedDict
-        for key, value in final_decision.items(): # Use final_decision here as it's the one for printing
-            if isinstance(value, list) and value: # If it's a list of proposals
-                print(f"  {key}:")
-                for item in value:
-                    if isinstance(item, dict): # e.g. a proposal_id string, or a dict itself
-                        print(f"    - {item}")
-                    else:
-                        print(f"    - {item}")
-            elif isinstance(value, dict) and value: # If it's a dictionary (like supporting_data)
-                 print(f"  {key}:")
-                 for sub_key, sub_value in value.items():
-                      print(f"    {sub_key}: {sub_value}")
-            else:
-                print(f"  {key}: {value}")
+def run_simulation_loop(
+    graph_instance: ForexTradingGraph,
+    broker_instance: SimulatedBroker,
+    currency_pair_to_trade: str,
+    market_data_sequence: List[Dict], # List of Candlestick-like dicts
+    initial_graph_state_overrides: Optional[Dict] = None
+):
+    print(f"\n--- Starting Simulation Loop for {currency_pair_to_trade} ---")
+    initial_account_info = broker_instance.get_account_info()
+    if initial_account_info:
+        print(f"Initial Account Info: Balance: {initial_account_info['balance']}, Equity: {initial_account_info['equity']}, Margin: {initial_account_info['margin']}, Free Margin: {initial_account_info['free_margin']}, Margin Level: {initial_account_info['margin_level']}%")
     else:
-        print("\n=== No final decision was returned or an error occurred. ===")
-        print("This might be expected if the graph logic leads to an END state")
-        print("without populating the 'forex_final_decision' field in the state,")
-        print("or if an error was caught and handled by returning None.")
+        print("Initial Account Info: Could not retrieve.")
 
-    print("\n--- End of Forex Trading Graph Test Script ---")
+
+    for i, bar_dict in enumerate(market_data_sequence):
+        # Ensure bar_dict is converted to Candlestick TypedDict for broker.update_market_data
+        # Or ensure broker.update_market_data can handle dicts.
+        # For now, assuming dicts are fine as per current SimulatedBroker structure for market_data.
+        # The Candlestick TypedDict is primarily for type hinting and explicit object creation.
+        current_bar_candlestick = Candlestick(**bar_dict)
+
+
+        bar_timestamp_unix = current_bar_candlestick['timestamp']
+        bar_datetime_obj = datetime.datetime.fromtimestamp(bar_timestamp_unix, tz=datetime.timezone.utc)
+        bar_iso_timestamp = bar_datetime_obj.isoformat()
+
+        print(f"\n--- Bar {i+1} | Time: {bar_iso_timestamp} | {currency_pair_to_trade} C: {current_bar_candlestick['close']} H: {current_bar_candlestick['high']} L: {current_bar_candlestick['low']} O: {current_bar_candlestick['open']} ---")
+
+        # 1. Update broker's knowledge of current time and market prices
+        broker_instance.update_current_time(bar_timestamp_unix)
+        broker_instance.update_market_data({currency_pair_to_trade: current_bar_candlestick})
+
+        # 2. Broker processes events based on new market data (before agent logic for this bar)
+        broker_instance.process_pending_orders()
+        broker_instance.check_for_sl_tp_triggers()
+
+        # 3. Agent system runs its logic for the current bar
+        current_iteration_state = {
+            "currency_pair": currency_pair_to_trade,
+            "current_simulated_time": bar_iso_timestamp,
+            "sub_agent_tasks": [], "market_regime": "TestRegime",
+            "scalper_proposal": None, "day_trader_proposal": None,
+            "swing_trader_proposal": None, "position_trader_proposal": None,
+            "proposals_from_sub_agents": [], "aggregated_proposals_for_meta_agent": None,
+            "forex_final_decision": None, "error_message": None
+        }
+        if initial_graph_state_overrides:
+            current_iteration_state.update(initial_graph_state_overrides)
+
+        print(f"Invoking graph for bar ending {bar_iso_timestamp}...")
+        # The graph instance passed should already have the broker instance from its __init__
+        final_state_for_bar = graph_instance.graph.invoke(current_iteration_state)
+
+        final_decision = final_state_for_bar.get("forex_final_decision")
+        if final_decision:
+            print(f"Graph produced decision: {final_decision['action']} for {final_decision['currency_pair']}")
+            # Here, one might implement logic to take the 'final_decision' and translate it
+            # into an actual order placement call to broker_instance.place_order(...)
+            # This part is crucial for a full backtest but is outside the scope of just running the graph's logic.
+            # For example:
+            # if final_decision['action'] == "EXECUTE_BUY":
+            #    broker_instance.place_order(symbol=final_decision['currency_pair'], type=OrderType.MARKET, ...)
+        else:
+            print("Graph did not produce a final decision for this bar.")
+
+        # 4. Broker processes margin calls after all trades and P/L updates for the bar
+        # _update_equity_and_margin is called by update_market_data, and after any order fills/closures.
+        # So, by the time check_for_margin_call is called, equity and margin_used should be current.
+        broker_instance.check_for_margin_call()
+
+        # 5. Log EOD/EOB account info
+        eob_account_info = broker_instance.get_account_info()
+        if eob_account_info:
+             print(f"End of Bar {i+1} Account Info: Balance: {eob_account_info['balance']}, Equity: {eob_account_info['equity']}, Margin: {eob_account_info['margin']}, Free Margin: {eob_account_info['free_margin']}, Margin Level: {eob_account_info['margin_level']}%")
+        else:
+            print(f"End of Bar {i+1} Account Info: Could not retrieve.")
+
+
+    print(f"\n--- Simulation Loop Finished for {currency_pair_to_trade} ---")
+    final_account_details = broker_instance.get_account_info()
+    if final_account_details:
+        print("Final Account Info:")
+        for key, value in final_account_details.items():
+            print(f"  {key}: {value}")
+    else:
+        print("Final Account Info: Could not retrieve.")
+
+    print("\nTrade History:")
+    for i, trade_event in enumerate(broker_instance.trade_history): # Use trade_history attribute
+        print(f"  {i+1}: {trade_event}")
+
+# Placeholder for Scenario 1 (to be implemented in next step)
+def test_scenario_winning_buy_tp():
+    print("\n\n===== SCENARIO 1: WINNING BUY MARKET ORDER (HITTING TP) =====")
+
+    # 1. Setup Broker
+    broker = setup_scenario_broker(
+        initial_capital=10000.0,
+        default_spread_pips={"EURUSD": 1.0}, # 1 pip spread
+        commission_per_lot={"EURUSD": 0.0} # No commission for this test
+    )
+
+    # 2. Prepare Market Data Sequence for EURUSD
+    start_time_unix = int(datetime.datetime(2023, 10, 1, 10, 0, 0, tzinfo=datetime.timezone.utc).timestamp())
+    eurusd_market_data: List[Dict[str, Any]] = [] # Ensure type for clarity
+    base_price = 1.08000
+
+    # Warm-up period (30 bars for indicators) - simple upward trend
+    for i in range(30):
+        ts = start_time_unix + (i * 3600)
+        eurusd_market_data.append({
+            "timestamp": float(ts), "open": base_price + (i * 0.00010),
+            "high": base_price + (i * 0.00010) + 0.00050,
+            "low": base_price + (i * 0.00010) - 0.00020,
+            "close": base_price + (i * 0.00010) + 0.00030,
+            "volume": float(1000 + i * 10)
+        })
+
+    trigger_bar_price_close = eurusd_market_data[-1]['close']
+    entry_bar_ts = start_time_unix + (30 * 3600)
+    eurusd_market_data.append({
+        "timestamp": float(entry_bar_ts), "open": trigger_bar_price_close,
+        "high": trigger_bar_price_close + 0.00050, "low": trigger_bar_price_close - 0.00020,
+        "close": trigger_bar_price_close + 0.00010, "volume": float(1200)
+    })
+
+    # Assuming entry around Ask of 1.08330 (close) + 0.00005 (half of 1 pip spread) = 1.08335
+    # TP target = 1.08335 + 0.00400 (40 pips) = 1.08735
+    tp_hit_bar_ts = start_time_unix + (31 * 3600)
+    eurusd_market_data.append({
+        "timestamp": float(tp_hit_bar_ts), "open": eurusd_market_data[-1]['close'],
+        "high": 1.08800, # Must be >= TP target 1.08735
+        "low": eurusd_market_data[-1]['close'] - 0.00010,
+        "close": 1.08750, "volume": float(1100)
+    })
+
+    for i in range(2): # Add a few more bars
+        ts = start_time_unix + ((32 + i) * 3600)
+        eurusd_market_data.append({
+            "timestamp": float(ts), "open": eurusd_market_data[-1]['close'],
+            "high": eurusd_market_data[-1]['close'] + 0.00020,
+            "low": eurusd_market_data[-1]['close'] - 0.00020,
+            "close": eurusd_market_data[-1]['close'] + (0.00010 * (1 if i % 2 == 0 else -1)),
+            "volume": float(1000)
+        })
+
+    broker.load_test_data("EURUSD", eurusd_market_data)
+
+    # 3. Initialize Graph
+    graph = ForexTradingGraph(broker=broker)
+
+    # 4. Execute Simulation Loop
+    # For this specific test, we assume the DayTraderAgent will be triggered on the "entry_bar_ts"
+    # and will decide to BUY. The graph logic currently processes all agents.
+    # We need a mechanism for the graph to actually place the trade.
+    # For now, we will manually place the order with the broker to test broker mechanics.
+    # This means we are testing the broker's TP mechanism, not the agent's decision making yet.
+
+    print("MANUALLY PLACING TEST ORDER for Scenario 1 to test broker TP...")
+    # Simulate agent's decision time as the beginning of the entry_bar_ts
+    broker.update_current_time(entry_bar_ts)
+    # Provide market data for that specific bar so get_current_price works for order placement
+    broker.update_market_data({"EURUSD": Candlestick(**eurusd_market_data[30])})
+
+
+    # Manually place the order that the agent *should* have made
+    # Assume DayTraderAgent default stop_loss_pips = 20, take_profit_pips = 40
+    # Assume volume 0.01 lots for P/L calculation test
+    entry_order_response = broker.place_order(
+        symbol="EURUSD",
+        order_type=OrderType.MARKET,
+        side=OrderSide.BUY,
+        volume=0.01, # Critical for P/L calculation test
+        stop_loss=None, # Will be calculated based on pips if agent logic were complete
+        take_profit=None # Will be calculated
+    )
+
+    test_position_id = None
+    if entry_order_response and entry_order_response.get("status") == "FILLED":
+        print(f"Manual BUY order placed and filled: {entry_order_response}")
+        test_position_id = entry_order_response.get("position_id")
+        # Manually set SL/TP on the position as agent would
+        # This requires a way to get the actual entry price.
+        actual_entry_price = entry_order_response.get("price")
+        if actual_entry_price and test_position_id:
+            pip_val, precision = broker._calculate_pip_value_and_precision("EURUSD") # Accessing private for test setup
+            sl_price = round(actual_entry_price - (20 * pip_val), precision)
+            tp_price = round(actual_entry_price + (40 * pip_val), precision)
+            broker.modify_order(test_position_id, stop_loss=sl_price, take_profit=tp_price)
+            print(f"Manually set SL: {sl_price}, TP: {tp_price} for position {test_position_id}")
+    else:
+        print(f"Manual BUY order failed or not filled: {entry_order_response}")
+        return # Cannot proceed with test if order isn't placed
+
+    # Now run the simulation loop for the bars *after* the order was placed
+    # The first bar in this sequence will be tp_hit_bar_ts
+    run_simulation_loop(
+        graph_instance=graph, # Graph is run, but not strictly making decisions for this test
+        broker_instance=broker,
+        currency_pair_to_trade="EURUSD",
+        market_data_sequence=eurusd_market_data[31:] # Start from the TP hit bar
+    )
+
+    print("===== VERIFICATION FOR SCENARIO 1 =====")
+    final_account_info = broker.get_account_info()
+    if final_account_info:
+        print(f"Final Balance: {final_account_info['balance']:.2f}")
+
+        # Expected P/L: 40 pips (since spread was 1 pip, entry was Ask, TP is hit exactly)
+        # Commission is 0 for this test.
+        # For EURUSD 0.01 lots, 1 pip = $0.10. So, 40 pips = $4.00 profit.
+        # (Entry price already includes half spread, TP is hit at that exact level)
+        expected_profit = 40 * 0.10
+        print(f"Expected Profit (0.01 lots, 0 commission, 1 pip spread, TP hit): ${expected_profit:.2f}")
+        print(f"Actual Profit: ${final_account_info['balance'] - 10000.0:.2f}")
+
+        found_buy_fill = False
+        found_tp_close = False
+        for event in broker.trade_history: # Use attribute directly
+            if event.get("event_type") == "MARKET_ORDER_FILLED" and event.get("side") == "BUY":
+                found_buy_fill = True
+                print(f"Found BUY Fill: {event}")
+            if event.get("event_type") == "POSITION_CLOSED" and event.get("reason_for_close") == "TAKE_PROFIT_HIT":
+                found_tp_close = True
+                print(f"Found TP Close: {event}")
+
+        if found_buy_fill and found_tp_close:
+            print("VERIFICATION: Winning BUY order filled and closed by TP successfully.")
+        else:
+            print("VERIFICATION ERROR: Winning BUY order TP scenario not fully verified in trade history.")
+    else:
+        print("VERIFICATION ERROR: Could not retrieve final account info.")
+    print("==========================================")
+
+
+# Placeholder for Scenario 2
+def test_scenario_losing_sell_sl():
+    print("\n\n===== SCENARIO 2: LOSING SELL MARKET ORDER (HITTING SL) =====")
+
+    # 1. Setup Broker
+    broker = setup_scenario_broker(
+        initial_capital=10000.0,
+        default_spread_pips={"EURUSD": 1.0}, # 1 pip spread
+        commission_per_lot={"EURUSD": 0.0} # No commission for this test
+    )
+
+    # 2. Prepare Market Data Sequence for EURUSD
+    start_time_unix = int(datetime.datetime(2023, 10, 2, 10, 0, 0, tzinfo=datetime.timezone.utc).timestamp())
+    eurusd_market_data: List[Dict[str, Any]] = []
+    base_price = 1.08500 # Start higher for a sell setup
+
+    # Warm-up period (30 bars for indicators) - simple downward trend
+    for i in range(30):
+        ts = start_time_unix + (i * 3600) # H1 timeframe
+        eurusd_market_data.append({
+            "timestamp": float(ts),
+            "open": base_price - (i * 0.00010),
+            "high": base_price - (i * 0.00010) + 0.00020,
+            "low": base_price - (i * 0.00010) - 0.00050,
+            "close": base_price - (i * 0.00010) - 0.00030,
+            "volume": float(1000 + i * 10)
+        })
+
+    trigger_bar_price_close = eurusd_market_data[-1]['close']
+    entry_bar_ts = start_time_unix + (30 * 3600) # This is timestamp of bar 31 (index 30)
+    eurusd_market_data.append({
+        "timestamp": float(entry_bar_ts), "open": trigger_bar_price_close,
+        "high": trigger_bar_price_close + 0.00020, "low": trigger_bar_price_close - 0.00010,
+        "close": trigger_bar_price_close - 0.00005, "volume": float(1200)
+    })
+
+    # Set broker's current time and market data for the moment of placing the order
+    broker.update_current_time(entry_bar_ts)
+    broker.update_market_data({"EURUSD": Candlestick(**eurusd_market_data[30])})
+
+    print(f"Attempting to place SELL order at simulated time: {datetime.datetime.fromtimestamp(entry_bar_ts, tz=datetime.timezone.utc).isoformat()}")
+
+    day_trader_sl_pips = 20.0
+    day_trader_tp_pips = 40.0 # Though TP won't be hit in this scenario
+
+    sell_order_response = broker.place_order(
+        symbol="EURUSD", order_type=OrderType.MARKET, side=OrderSide.SELL,
+        volume=0.01, comment="Test SL Scenario - Manual Sell"
+    )
+
+    position_id_to_track = None
+    if sell_order_response and sell_order_response.get("status") == "FILLED":
+        print(f"Manual SELL Order Filled: {sell_order_response}")
+        position_id_to_track = sell_order_response.get("position_id")
+
+        if position_id_to_track:
+            fill_price = sell_order_response['price']
+            # Use broker's helper for pip unit value for accuracy
+            pip_unit_value = broker._get_pip_value_for_sl_tp("EURUSD")
+            price_precision = broker._get_price_precision("EURUSD")
+
+            sl_price = round(fill_price + (day_trader_sl_pips * pip_unit_value), price_precision)
+            tp_price = round(fill_price - (day_trader_tp_pips * pip_unit_value), price_precision)
+            print(f"Setting SL/TP for position {position_id_to_track}: SL={sl_price}, TP={tp_price}. Fill price: {fill_price}")
+            broker.modify_order(position_id_to_track, new_stop_loss=sl_price, new_take_profit=tp_price)
+        else:
+            print("ERROR: Could not get position_id from filled order to set SL/TP.")
+            return
+    else:
+        print(f"ERROR: Manual SELL Order failed to fill: {sell_order_response}")
+        return
+
+    # SL is approx fill_price (e.g. 1.08170 from comments in prompt) + 0.00200 = 1.08370
+    # This bar (index 31) needs its HIGH to hit that SL
+    sl_hit_bar_ts = entry_bar_ts + 3600
+    eurusd_market_data.append({
+        "timestamp": float(sl_hit_bar_ts), "open": eurusd_market_data[-1]['close'],
+        "high": 1.08400, # Ensure this is >= SL target (e.g. if fill was 1.08170, SL is 1.08370)
+        "low": eurusd_market_data[-1]['close'] - 0.00010,
+        "close": 1.08380, "volume": float(1100)
+    })
+
+    for i in range(2): # Add a few more bars
+        ts = sl_hit_bar_ts + ((i + 1) * 3600)
+        eurusd_market_data.append({
+            "timestamp": float(ts), "open": eurusd_market_data[-1]['close'],
+            "high": eurusd_market_data[-1]['close'] + 0.00020,
+            "low": eurusd_market_data[-1]['close'] - 0.00020,
+            "close": eurusd_market_data[-1]['close'] + (0.00010 * (1 if i % 2 == 0 else -1)),
+            "volume": float(1000)
+        })
+
+    broker.load_test_data("EURUSD", eurusd_market_data)
+
+    graph = ForexTradingGraph(broker=broker)
+
+    # Simulation loop starts from the bar that can hit the SL (index 31)
+    run_simulation_loop(
+        graph_instance=graph, broker_instance=broker, currency_pair_to_trade="EURUSD",
+        market_data_sequence=eurusd_market_data[31:]
+    )
+
+    print("===== VERIFICATION FOR SCENARIO 2 =====")
+    final_account_info = broker.get_account_info()
+    if final_account_info:
+        print(f"Final Balance: {final_account_info['balance']:.2f}")
+        # Expected Loss: 20 pips SL. Spread is paid on entry.
+        # For EURUSD 0.01 lots, 1 pip = $0.10. So, 20 pips = $2.00 loss from SL.
+        # Commission is 0.
+        expected_loss = day_trader_sl_pips * 0.10
+        print(f"Expected Loss (0.01 lots, 0 commission, SL hit): ${expected_loss:.2f}")
+        # Actual loss calculation from balance change:
+        actual_loss_from_balance = 10000.0 - final_account_info['balance']
+        print(f"Actual Loss reflected in balance: ${actual_loss_from_balance:.2f}")
+
+        found_sell_fill = False
+        found_sl_close = False
+        for event in broker.trade_history:
+            if event.get("event_type") == "MARKET_ORDER_FILLED" and event.get("side") == "SELL":
+                found_sell_fill = True
+                print(f"Found SELL Fill: {event}")
+            if event.get("event_type") == "POSITION_CLOSED" and event.get("reason_for_close") == "STOP_LOSS_HIT":
+                found_sl_close = True
+                print(f"Found SL Close: {event}")
+
+        if found_sell_fill and found_sl_close:
+            print("VERIFICATION: Losing SELL order filled and closed by SL successfully.")
+        else:
+            print("VERIFICATION ERROR: Losing SELL order SL scenario not fully verified in trade history.")
+    else:
+        print("VERIFICATION ERROR: Could not retrieve final account info.")
+    print("==========================================")
+
+def main():
+    print("--- Main Test Runner for Forex Trading Scenarios ---")
+
+    # Call scenario functions
+    test_scenario_winning_buy_tp()
+    test_scenario_losing_sell_sl()
 
 if __name__ == "__main__":
     main()

--- a/TradingAgents/tradingagents/broker_interface/simulated_broker.py
+++ b/TradingAgents/tradingagents/broker_interface/simulated_broker.py
@@ -1,222 +1,318 @@
-from typing import List, Dict, Optional, Any, Tuple # Ensure Tuple is imported
+from typing import List, Dict, Optional, Any, Tuple
 from tradingagents.broker_interface.base import BrokerInterface
-# Import the actual TypedDicts and Enums
 from tradingagents.forex_utils.forex_states import (
     PriceTick, Candlestick, AccountInfo, OrderResponse, Position,
     OrderType, OrderSide, TimeInForce
 )
 import datetime
 import time
-import random # For slippage
-import uuid # For unique IDs
+import random
+import uuid
 
 class SimulatedBroker(BrokerInterface):
     def __init__(self, initial_capital: float = 10000.0):
         self.initial_capital = initial_capital
         self.balance = initial_capital
         self.equity = initial_capital
-        self._connected = True # Always connected for sim
-        self.current_simulated_time_unix = time.time() # Fallback, should be updated by backtester
+        self._connected = True
+        self.current_simulated_time_unix = time.time()
 
         self.open_positions: Dict[str, Position] = {}
-        self.pending_orders: Dict[str, OrderResponse] = {} # Not fully used in this step
+        self.pending_orders: Dict[str, Dict[str, Any]] = {} # Storing as dict for flexibility with SL/TP
         self.trade_history: List[Dict] = []
 
-        self.order_fill_logic: str = "CURRENT_BAR_CLOSE" # Or "NEXT_BAR_OPEN"
-        self.fixed_slippage_pips: float = 0.2 # Example: 0.2 pips slippage
+        self.order_fill_logic: str = "CURRENT_BAR_CLOSE"
+        self.fixed_slippage_pips: float = 0.2
 
-        # Store current bar data provided by a backtester/data handler
         self.current_market_data: Dict[str, Candlestick] = {}
 
-        # Configuration for symbols (can be expanded or made external)
         self.default_spread_pips: Dict[str, float] = {
-            "EURUSD": 0.5, "GBPUSD": 0.6, "USDJPY": 0.5, "AUDUSD": 0.7, "USDCAD": 0.7, "XAUUSD": 2.0 # Gold spread in pips (e.g. 20 points if 1 pip = $0.10 for XAU)
+            "EURUSD": 0.5, "GBPUSD": 0.6, "USDJPY": 0.5, "AUDUSD": 0.7, "USDCAD": 0.7, "XAUUSD": 2.0
         }
-        self.commission_per_lot: Dict[str, float] = { # Per 1.0 lot (100,000 units) round turn
+        self.commission_per_lot: Dict[str, float] = {
             "EURUSD": 7.0, "GBPUSD": 7.0, "USDJPY": 7.0, "AUDUSD": 7.0, "USDCAD": 7.0, "XAUUSD": 7.0
         }
-        self.leverage: int = 100 # e.g., 100:1 leverage, margin requirement is 1/100 = 1%
+        self.leverage: int = 100
         self.margin_used: float = 0.0
+        self.account_currency = "USD"
+        self.margin_call_warning_level_pct = 100.0 # e.g., 100%
+        self.stop_out_level_pct = 50.0          # e.g., 50%
+        self.test_data_store: Dict[str, List[Dict]] = {} # Added for test data
 
-        print(f"SimulatedBroker initialized. Capital: {initial_capital}, Slippage: {self.fixed_slippage_pips} pips, Leverage: {self.leverage}:1")
+        print(f"SimulatedBroker initialized. Capital: {initial_capital}, Slippage: {self.fixed_slippage_pips} pips, Leverage: {self.leverage}:1, Account Currency: {self.account_currency}, Margin Warning: {self.margin_call_warning_level_pct}%, Stop Out: {self.stop_out_level_pct}%")
+
+    def load_test_data(self, symbol: str, data_sequence: List[Dict]):
+        # data_sequence should be a list of Candlestick-like dictionaries
+        # already sorted chronologically
+        print(f"SimBroker: Loading {len(data_sequence)} bars of test data for {symbol}.")
+        self.test_data_store[symbol.upper()] = data_sequence
 
     def _generate_unique_id(self) -> str:
         return str(uuid.uuid4())
 
+    def _get_symbol_info(self, symbol: str) -> Optional[Dict[str, Any]]:
+        symbol_upper = symbol.upper()
+        if len(symbol_upper) == 6 and symbol_upper.isalnum():
+            base = symbol_upper[:3]
+            quote = symbol_upper[3:]
+            if "JPY" == quote:
+                return {"base_currency": base, "quote_currency": quote, "price_precision": 3, "point_size": 0.001, "pip_unit_value": 0.01}
+            else:
+                return {"base_currency": base, "quote_currency": quote, "price_precision": 5, "point_size": 0.00001, "pip_unit_value": 0.0001}
+        elif symbol_upper in ["XAUUSD", "GOLD"]:
+            return {"base_currency": "XAU", "quote_currency": "USD", "price_precision": 2, "point_size": 0.01, "pip_unit_value": 0.1}
+        print(f"SimBroker._get_symbol_info: Symbol info not configured for {symbol}")
+        return None
+
     def _get_point_size(self, symbol: str) -> float:
-        pair_normalized = symbol.upper()
-        if "JPY" in pair_normalized: return 0.001
-        if "XAU" in pair_normalized or "GOLD" in pair_normalized: return 0.01
-        return 0.00001
+        info = self._get_symbol_info(symbol)
+        return info["point_size"] if info else 0.00001
 
     def _get_price_precision(self, symbol: str) -> int:
-        pair_normalized = symbol.upper()
-        if "JPY" in pair_normalized: return 3
-        if "XAU" in pair_normalized or "GOLD" in pair_normalized: return 2
-        return 5
+        info = self._get_symbol_info(symbol)
+        return info["price_precision"] if info else 5
 
-    def _get_pip_value_for_sl_tp(self, symbol: str) -> float:
-        # This is the value of 1 pip for SL/TP calculations in price terms
-        pair_normalized = symbol.upper()
-        if "JPY" in pair_normalized: return 0.01
-        # For XAUUSD, 1 pip is often considered $0.10 if contract size is 100 oz and price is per oz.
-        # If point size is 0.01, then a "pip" for XAU might be 10 points or $0.10.
-        # Or if "pip" for XAU means the second decimal (like other pairs with 0.01 point size), then it's 0.01.
-        # For simplicity, let's assume "pip" for XAU here refers to the second decimal place (same as JPY pairs).
-        if "XAU" in pair_normalized or "GOLD" in pair_normalized: return 0.01
-        return 0.0001
+    def _get_pip_value_for_sl_tp(self, symbol: str) -> float: # This is the price change for 1 pip
+        info = self._get_symbol_info(symbol)
+        return info["pip_unit_value"] if info else 0.0001
 
+    def _get_exchange_rate(self, from_currency: str, to_currency: str) -> Optional[float]:
+        if from_currency == to_currency: return 1.0
+        direct_pair = f"{from_currency}{to_currency}".upper()
+        inverse_pair = f"{to_currency}{from_currency}".upper()
+
+        current_market_direct = self.current_market_data.get(direct_pair)
+        if current_market_direct: return current_market_direct['close']
+
+        current_market_inverse = self.current_market_data.get(inverse_pair)
+        if current_market_inverse and current_market_inverse['close'] != 0:
+            return 1.0 / current_market_inverse['close']
+
+        # Simplified USD cross for non-USD account currency (more complex logic needed for full support)
+        if self.account_currency != "USD": # Only attempt USD cross if account is not USD
+             # Try from_currency -> USD -> to_currency
+            from_usd_rate = self._get_exchange_rate(from_currency, "USD")
+            usd_to_rate = self._get_exchange_rate("USD", to_currency)
+            if from_usd_rate and usd_to_rate:
+                return from_usd_rate * usd_to_rate
+
+        print(f"SimBroker._get_exchange_rate: Exchange rate for {from_currency}/{to_currency} not found. Current time: {self.current_simulated_time_unix}")
+        return None
+
+    def calculate_pip_value_in_account_currency(self, symbol: str, volume_lots: float) -> Optional[float]:
+        symbol_info = self._get_symbol_info(symbol)
+        if not symbol_info: return None
+        pip_unit_val = symbol_info['pip_unit_value']
+        quote_currency = symbol_info['quote_currency']
+        contract_size = 100000
+        value_of_one_pip_in_quote_currency = pip_unit_val * contract_size * volume_lots
+        if quote_currency == self.account_currency:
+            return value_of_one_pip_in_quote_currency
+        exchange_rate = self._get_exchange_rate(quote_currency, self.account_currency)
+        if exchange_rate is None:
+            print(f"SimBroker.calculate_pip_value: Failed to get exchange rate for {quote_currency} to {self.account_currency} for symbol {symbol}")
+            return None
+        return value_of_one_pip_in_quote_currency * exchange_rate
+
+    def calculate_pnl_in_account_currency(self, symbol: str, side: OrderSide, volume_lots: float, entry_price: float, close_price: float) -> Optional[float]:
+        symbol_info = self._get_symbol_info(symbol)
+        if not symbol_info: return None
+        price_difference = (close_price - entry_price) if side == OrderSide.BUY else (entry_price - close_price)
+        if symbol_info['pip_unit_value'] == 0: return None
+        pips_moved = price_difference / symbol_info['pip_unit_value']
+        value_of_one_pip_for_one_lot = self.calculate_pip_value_in_account_currency(symbol, 1.0)
+        if value_of_one_pip_for_one_lot is None: return None
+        return pips_moved * value_of_one_pip_for_one_lot * volume_lots
 
     def _get_spread_in_price_terms(self, symbol: str) -> float:
         pips = self.default_spread_pips.get(symbol.upper(), 1.0)
-        pip_price_unit = self._get_pip_value_for_sl_tp(symbol) # 0.0001 for EURUSD, 0.01 for USDJPY
+        pip_price_unit = self._get_pip_value_for_sl_tp(symbol)
         return pips * pip_price_unit
 
     def _calculate_commission(self, symbol: str, volume_lots: float) -> float:
-        # commission_per_lot is round-turn.
         return self.commission_per_lot.get(symbol.upper(), 0.0) * volume_lots
 
     def _calculate_margin_required(self, symbol: str, volume_lots: float, entry_price: float) -> float:
         contract_size = 100000
-        notional_value = volume_lots * contract_size * entry_price
-        # This is simplified; proper calculation depends on whether symbol base is account currency.
-        # E.g., if trading EURUSD on a USD account, notional value is in USD (volume_lots * 100k EUR * EURUSD_price).
-        # If trading USDJPY on a USD account, notional value is in JPY (volume_lots * 100k USD), which then needs to be converted if leverage applies to the base.
-        # Standard Forex margin: (Market Price * Volume in Base Currency) / Leverage, result in Quote currency. Then convert to Account currency.
-        # For simplicity, assuming Quote currency is USD or conversion is handled implicitly by "entry_price".
-        return notional_value / self.leverage
+        symbol_info = self._get_symbol_info(symbol)
+        if not symbol_info:
+            print(f"SimBroker._calculate_margin_required: Symbol info for {symbol} not found. Margin might be inaccurate.")
+            return (volume_lots * contract_size * entry_price) / self.leverage # Fallback
+
+        base_currency = symbol_info['base_currency']
+        quote_currency = symbol_info['quote_currency']
+
+        # Notional value in base currency units * entry_price (base/quote) = notional value in quote currency
+        notional_value_in_quote_currency = volume_lots * contract_size * entry_price
+
+        margin_in_base_currency = (volume_lots * contract_size) / self.leverage # Standard formula: LotSize / Leverage
+
+        if base_currency == self.account_currency:
+            return margin_in_base_currency * entry_price # if base is USD, entry is XXX/USD, gives USD margin. This seems more standard.
+                                                        # Or rather, (Vol * CS * Price) / Lev for quote currency margin, then convert.
+                                                        # Let's use (Vol * CS * Price) / Lev for quote currency margin, then convert to Account Currency
+
+        # Standard: (Market Price * Volume in Base Currency) / Leverage = Margin in Quote Currency
+        # Then convert Margin in Quote Currency to Account Currency.
+        # Notional Value in Quote Currency = volume_lots * contract_size * entry_price
+
+        # Margin required in terms of the base currency of the pair, converted to account currency
+        # Example: EURUSD, 1 lot (100k EUR). Margin req = 1000 EUR (at 100:1). Convert 1000 EUR to USD.
+        # If trading 1 lot EURUSD (100,000 EUR) at 1.0800, with 100:1 leverage:
+        # Margin needed = (100,000 EUR / 100) = 1,000 EUR.
+        # Convert 1,000 EUR to USD: 1,000 * EURUSD_rate (if account is USD).
+
+        margin_in_base_currency_units = (volume_lots * contract_size) / self.leverage
+
+        if base_currency == self.account_currency:
+            return margin_in_base_currency_units # e.g. for USD/JPY on USD account, margin is in USD
+
+        # Base currency needs to be converted to account currency
+        exchange_rate_base_to_account = self._get_exchange_rate(base_currency, self.account_currency)
+        if exchange_rate_base_to_account is None:
+            print(f"SimBroker._calculate_margin_required: Could not get exchange rate {base_currency}{self.account_currency} for margin calc of {symbol}. Using simplified margin.")
+            # Fallback to quote currency calculation if base conversion fails (less accurate but better than nothing)
+            if quote_currency == self.account_currency: return notional_value_in_quote_currency / self.leverage
+            rate_quote_to_acc = self._get_exchange_rate(quote_currency, self.account_currency)
+            return (notional_value_in_quote_currency / self.leverage) * rate_quote_to_acc if rate_quote_to_acc else (notional_value_in_quote_currency / self.leverage)
+
+        return margin_in_base_currency_units * exchange_rate_base_to_account
 
     def update_current_time(self, simulated_time_unix: float):
         self.current_simulated_time_unix = simulated_time_unix
 
     def update_market_data(self, market_data: Dict[str, Candlestick]):
         self.current_market_data = market_data
-        self._update_equity_and_margin() # Update P/L and equity after new prices
+        self._update_equity_and_margin()
 
     def connect(self, credentials: Dict[str, Any]) -> bool:
-        print("SimulatedBroker: connect() called (always successful).")
         self._connected = True
         return True
 
     def disconnect(self) -> None:
-        print("SimulatedBroker: disconnect() called.")
         self._connected = False
 
     def is_connected(self) -> bool:
         return self._connected
 
     def get_current_price(self, symbol: str) -> Optional[PriceTick]:
-        # This should use self.current_market_data (current bar) to derive a PriceTick
-        # print(f"SimulatedBroker: get_current_price({symbol}) called for time {datetime.datetime.fromtimestamp(self.current_simulated_time_unix, tz=datetime.timezone.utc).isoformat()}")
         current_bar = self.current_market_data.get(symbol)
         if not current_bar:
-            # Fallback to very basic static prices if no current bar data (e.g., for initial tests)
             if symbol == "EURUSD": base_bid = 1.08500
             elif symbol == "GBPUSD": base_bid = 1.27100
-            else: print(f"SimulatedBroker: No current bar data or fallback static price for {symbol}"); return None
+            else: print(f"SimBroker: No current bar data or fallback static price for {symbol}"); return None
             spread = self._get_spread_in_price_terms(symbol)
-            return PriceTick(symbol=symbol, timestamp=self.current_simulated_time_unix, bid=base_bid, ask=base_bid + spread, last=base_bid + (spread/2))
-
-        # Derive tick from current bar's close, applying spread
-        # This assumes get_current_price is called *after* new bar data is available for the "current" moment
+            precision = self._get_price_precision(symbol)
+            return PriceTick(symbol=symbol, timestamp=self.current_simulated_time_unix,
+                             bid=round(base_bid, precision), ask=round(base_bid + spread, precision),
+                             last=round(base_bid + (spread/2), precision))
         spread_amount = self._get_spread_in_price_terms(symbol)
-        bid_price = round(current_bar['close'] - (spread_amount / 2.0), self._get_price_precision(symbol))
-        ask_price = round(current_bar['close'] + (spread_amount / 2.0), self._get_price_precision(symbol))
-
-        return PriceTick(
-            symbol=symbol,
-            timestamp=self.current_simulated_time_unix,
-            bid=bid_price,
-            ask=ask_price,
-            last=current_bar['close']
-        )
+        precision = self._get_price_precision(symbol)
+        bid_price = round(current_bar['close'] - (spread_amount / 2.0), precision)
+        ask_price = round(current_bar['close'] + (spread_amount / 2.0), precision)
+        return PriceTick(symbol=symbol, timestamp=self.current_simulated_time_unix, bid=bid_price, ask=ask_price, last=current_bar['close'])
 
     def get_historical_data(self, symbol: str, timeframe_str: str,
                               start_time_unix: float, end_time_unix: Optional[float] = None,
-                              count: Optional[int] = None) -> List[Candlestick]:
-        # print(f"SimulatedBroker: get_historical_data({symbol}, {timeframe_str}, from {datetime.datetime.fromtimestamp(start_time_unix, tz=datetime.timezone.utc).isoformat()} to {datetime.datetime.fromtimestamp(end_time_unix, tz=datetime.timezone.utc).isoformat() if end_time_unix else 'N/A (count based)'}, count={count}) called.")
-        dummy_bars: List[Candlestick] = []
-        time_step_seconds = self._get_timeframe_seconds_approx(timeframe_str) # Using internal helper now
+                              count: Optional[int] = None) -> List[Dict]: # Candlestick
 
-        actual_end_time = end_time_unix if end_time_unix is not None else self.current_simulated_time_unix
+            symbol_upper = symbol.upper()
+            # Use current_simulated_time_unix as the absolute end point for any historical data request
+            # to prevent look-ahead bias.
+            effective_end_time_unix = min(end_time_unix if end_time_unix is not None else self.current_simulated_time_unix,
+                                          self.current_simulated_time_unix)
 
-        if count is not None:
-            num_bars_to_generate = count
-            current_bar_start_time_unix = actual_end_time - time_step_seconds
-        else:
-            if actual_end_time < start_time_unix: return []
-            num_bars_to_generate = int((actual_end_time - start_time_unix) / time_step_seconds)
-            current_bar_start_time_unix = actual_end_time - time_step_seconds
+            print(f"SimBroker: get_historical_data({symbol_upper}, TF:{timeframe_str}) requested range: "
+                  f"{datetime.datetime.fromtimestamp(start_time_unix, tz=datetime.timezone.utc).isoformat()} to "
+                  f"{datetime.datetime.fromtimestamp(effective_end_time_unix, tz=datetime.timezone.utc).isoformat()}. Current sim time: {datetime.datetime.fromtimestamp(self.current_simulated_time_unix, tz=datetime.timezone.utc).isoformat()}")
 
-        for i in range(num_bars_to_generate):
-            bar_open_timestamp = current_bar_start_time_unix - (i * time_step_seconds)
-            if bar_open_timestamp < start_time_unix: continue
+            if symbol_upper in self.test_data_store:
+                all_bars_for_symbol = self.test_data_store[symbol_upper]
+                # Filter bars within the requested range [start_time_unix, effective_end_time_unix]
 
-            idx_from_oldest = num_bars_to_generate - 1 - i
-            base_price = 1.0700 + (idx_from_oldest * 0.0001) # Example for EURUSD like pair
-            if "JPY" in symbol.upper(): base_price = 150.00 + (idx_from_oldest * 0.01)
-            elif "XAU" in symbol.upper(): base_price = 2300.00 + (idx_from_oldest * 0.1)
+                relevant_bars = [
+                    Candlestick(**bar) for bar in all_bars_for_symbol # Ensure cast to TypedDict if stored as raw dicts
+                    if bar['timestamp'] >= start_time_unix and bar['timestamp'] <= effective_end_time_unix
+                ]
 
+                # If count is specified, take the last 'count' bars from the filtered list
+                if count is not None and len(relevant_bars) > count:
+                    relevant_bars = relevant_bars[-count:]
 
-            precision = self._get_price_precision(symbol)
-            open_val = round(base_price + (random.uniform(-0.0005, 0.0005) if "JPY" not in symbol.upper() else random.uniform(-0.05,0.05)), precision)
-            close_val = round(base_price + (random.uniform(-0.0005, 0.0005) if "JPY" not in symbol.upper() else random.uniform(-0.05,0.05)), precision)
-            high_val = round(max(open_val, close_val) + (random.uniform(0,0.0003) if "JPY" not in symbol.upper() else random.uniform(0,0.03)), precision)
-            low_val = round(min(open_val, close_val) - (random.uniform(0,0.0003) if "JPY" not in symbol.upper() else random.uniform(0,0.03)), precision)
+                print(f"SimBroker: Returning {len(relevant_bars)} bars from test_data_store for {symbol_upper}.")
+                return relevant_bars
+            else: # Fallback to dummy generation if no test data loaded for this symbol
+                print(f"SimBroker: No test_data_store for {symbol_upper}. Generating dummy historical data.")
+                # ... (keep existing dummy generation logic here, but ensure it also respects effective_end_time_unix)
+                # For simplicity, this subtask can omit reimplementing the full dummy generation here
+                # if the focus is on using test_data_store. Just return empty list if not in store.
+                # For this subtask, let's make it return empty if not in test_data_store to force test data usage.
+                # Reinstating dummy generation for completeness, but ensuring it respects effective_end_time_unix
+                dummy_bars_generated: List[Candlestick] = []
+                time_step_seconds = self._get_timeframe_seconds_approx(timeframe_str)
 
-            dummy_bars.append(Candlestick(
-                timestamp=bar_open_timestamp, open=open_val, high=high_val, low=low_val, close=close_val,
-                volume=float(1000 + (idx_from_oldest * 10) + random.randint(-100, 100))
-            ))
+                # Determine num_bars_to_generate for dummy data
+                if count is not None:
+                    num_to_gen = count
+                    # Start generating backwards from effective_end_time_unix
+                    current_bar_open_time_for_dummy = effective_end_time_unix - time_step_seconds
+                else:
+                    if effective_end_time_unix < start_time_unix: return []
+                    num_to_gen = int((effective_end_time_unix - start_time_unix) / time_step_seconds)
+                    current_bar_open_time_for_dummy = effective_end_time_unix - time_step_seconds
 
-        dummy_bars.sort(key=lambda x: x['timestamp'])
-        final_bars = [bar for bar in dummy_bars if bar['timestamp'] >= start_time_unix and bar['timestamp'] < actual_end_time]
-        # print(f"SimulatedBroker: Returning {len(final_bars)} dummy bars for {symbol}.")
-        return final_bars
+                for i in range(num_to_gen):
+                    bar_open_timestamp = current_bar_open_time_for_dummy - (i * time_step_seconds)
+                    if bar_open_timestamp < start_time_unix: continue # Ensure not earlier than requested start
 
-    def _get_timeframe_seconds_approx(self, timeframe_str: str) -> int: # Copied from agent for now
+                    idx_from_oldest = num_to_gen - 1 - i # To make prices somewhat trend
+                    base_price = 1.0700 + (idx_from_oldest * 0.0001)
+                    if "JPY" in symbol_upper: base_price = 150.00 + (idx_from_oldest * 0.01)
+                    elif "XAU" in symbol_upper: base_price = 2300.00 + (idx_from_oldest * 0.1)
+                    precision = self._get_price_precision(symbol_upper)
+                    point = self._get_point_size(symbol_upper) * 10
+                    open_val = round(base_price + random.uniform(-point, point), precision)
+                    close_val = round(base_price + random.uniform(-point, point), precision)
+                    high_val = round(max(open_val, close_val) + random.uniform(0, point*2), precision)
+                    low_val = round(min(open_val, close_val) - random.uniform(0, point*2), precision)
+                    dummy_bars_generated.append(Candlestick(timestamp=bar_open_timestamp, open=open_val, high=high_val, low=low_val, close=close_val, volume=float(random.randint(500,2000) + idx_from_oldest)))
+
+                dummy_bars_generated.sort(key=lambda x: x['timestamp']) # Ensure chronological
+                # Final filter for exactness, though loop condition should mostly handle start_time_unix
+                final_dummy_bars = [b for b in dummy_bars_generated if b['timestamp'] >= start_time_unix and b['timestamp'] < effective_end_time_unix]
+                print(f"SimBroker: Generated and returning {len(final_dummy_bars)} dummy bars for {symbol_upper}.")
+                return final_dummy_bars
+
+    def _get_timeframe_seconds_approx(self, timeframe_str: str) -> int:
         timeframe_str = timeframe_str.upper()
-        if "M1" == timeframe_str: return 60
-        if "M5" == timeframe_str: return 5 * 60
-        if "M15" == timeframe_str: return 15 * 60
-        if "M30" == timeframe_str: return 30 * 60
-        if "H1" == timeframe_str: return 60 * 60
-        if "H4" == timeframe_str: return 4 * 60 * 60
-        if "D1" == timeframe_str: return 24 * 60 * 60
+        if "M1" == timeframe_str: return 60;  # ... (rest of timeframes)
+        if "M5" == timeframe_str: return 5 * 60;
+        if "M15" == timeframe_str: return 15 * 60;
+        if "M30" == timeframe_str: return 30 * 60;
+        if "H1" == timeframe_str: return 60 * 60;
+        if "H4" == timeframe_str: return 4 * 60 * 60;
+        if "D1" == timeframe_str: return 24 * 60 * 60;
+        if "W1" == timeframe_str: return 7 * 24 * 60 * 60;
+        if "MN1" == timeframe_str: return 30 * 24 * 60 * 60;
         return 60 * 60
 
     def get_account_info(self) -> Optional[AccountInfo]:
         if not self.is_connected(): return None
-        # _update_equity_and_margin() # Call this if it's not called by an external loop frequently
-
+        # _update_equity_and_margin() # Called by update_market_data, or before critical checks
         free_margin = self.equity - self.margin_used
         margin_level = (self.equity / self.margin_used * 100) if self.margin_used > 0 else float('inf')
-
-        return AccountInfo(
-            account_id=self._generate_unique_id()[:8], # Short UID for account
-            balance=round(self.balance, 2),
-            equity=round(self.equity, 2),
-            margin=round(self.margin_used, 2),
-            free_margin=round(free_margin, 2),
-            margin_level=round(margin_level, 2) if margin_level != float('inf') else float('inf'),
-            currency="USD"
-        )
+        return AccountInfo(account_id=self._generate_unique_id()[:8], balance=round(self.balance, 2), equity=round(self.equity, 2), margin=round(self.margin_used, 2), free_margin=round(free_margin, 2), margin_level=round(margin_level, 2) if margin_level != float('inf') else float('inf'), currency=self.account_currency)
 
     def place_order(self, symbol: str, order_type: OrderType, side: OrderSide, volume: float,
                       price: Optional[float] = None, stop_loss: Optional[float] = None,
                       take_profit: Optional[float] = None, time_in_force: TimeInForce = TimeInForce.GTC,
                       magic_number: Optional[int] = 0, comment: Optional[str] = "") -> OrderResponse:
-
         order_id = self._generate_unique_id()
         timestamp_unix = self.current_simulated_time_unix
+        if not self.is_connected(): return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Broker not connected.")
+        current_bar = self.current_market_data.get(symbol)
+        if not current_bar: return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message=f"Market data not available for {symbol} at {datetime.datetime.fromtimestamp(timestamp_unix, tz=datetime.timezone.utc).isoformat()}.")
 
-        if not self.is_connected():
-            return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Broker not connected.")
-
-        if symbol not in self.current_market_data or not self.current_market_data[symbol]:
-            return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message=f"Market data not available for {symbol} at {datetime.datetime.fromtimestamp(timestamp_unix, tz=datetime.timezone.utc).isoformat()}.")
-
-        current_bar = self.current_market_data[symbol]
         price_precision = self._get_price_precision(symbol)
 
         if order_type == OrderType.MARKET:
@@ -224,474 +320,334 @@ class SimulatedBroker(BrokerInterface):
             spread_amount = self._get_spread_in_price_terms(symbol)
             point_size = self._get_point_size(symbol)
             slippage_in_price = self.fixed_slippage_pips * point_size
-
             entry_price_final: float
-            if side == OrderSide.BUY:
-                entry_price_final = fill_price_base + (spread_amount / 2) # Ask
-                entry_price_final += random.uniform(0, slippage_in_price)
-            elif side == OrderSide.SELL:
-                entry_price_final = fill_price_base - (spread_amount / 2) # Bid
-                entry_price_final -= random.uniform(0, slippage_in_price)
-            else: # Should not happen with Enum
-                 return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Invalid order side.")
-
-            entry_price_final = round(entry_price_final, price_precision)
+            if side == OrderSide.BUY: entry_price_final = round(fill_price_base + (spread_amount / 2) + random.uniform(0, slippage_in_price), price_precision)
+            elif side == OrderSide.SELL: entry_price_final = round(fill_price_base - (spread_amount / 2) - random.uniform(0, slippage_in_price), price_precision)
+            else: return OrderResponse(order_id=order_id, status="REJECTED", error_message="Invalid order side.")
 
             margin_for_this_trade = self._calculate_margin_required(symbol, volume, entry_price_final)
-            current_acc_info = self.get_account_info() # This calls _update_equity_and_margin internally if designed so, or relies on external calls.
-                                                 # For this flow, let's assume get_account_info provides current free_margin.
-            if not current_acc_info or current_acc_info['free_margin'] < margin_for_this_trade:
-                 return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=entry_price_final, timestamp=timestamp_unix, error_message=f"Insufficient free margin. Need: {margin_for_this_trade:.2f}, Have: {current_acc_info['free_margin'] if current_acc_info else 'N/A'}")
+            # Ensure equity/margin is current before checking free margin
+            self._update_equity_and_margin() # Call here to ensure fresh values before check
+            free_margin = self.equity - self.margin_used
+            if free_margin < margin_for_this_trade:
+                 return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=entry_price_final, timestamp=timestamp_unix, error_message=f"Insufficient free margin. Need: {margin_for_this_trade:.2f}, Have: {free_margin:.2f}")
 
             commission_cost = self._calculate_commission(symbol, volume)
             position_id = self._generate_unique_id()
-
-            new_position = Position(
-                position_id=position_id, symbol=symbol, side=side, volume=volume,
-                entry_price=entry_price_final, current_price=entry_price_final,
-                profit_loss= -commission_cost, # Initial P/L
-                stop_loss=stop_loss, take_profit=take_profit, open_time=timestamp_unix,
-                magic_number=magic_number, comment=comment
-            )
+            new_position = Position(position_id=position_id, symbol=symbol, side=side, volume=volume, entry_price=entry_price_final, current_price=entry_price_final, profit_loss= -commission_cost, stop_loss=stop_loss, take_profit=take_profit, open_time=timestamp_unix, magic_number=magic_number, comment=comment)
             self.open_positions[position_id] = new_position
-
             self.balance -= commission_cost
             self.margin_used += margin_for_this_trade
-            self._update_equity_and_margin() # Update equity immediately after balance/margin change
-
-            self.trade_history.append({
-                "event_type": "MARKET_ORDER_FILLED", "timestamp": timestamp_unix, "order_id": order_id,
-                "position_id": position_id, "symbol": symbol, "side": side.value,
-                "volume": volume, "fill_price": entry_price_final, "sl": stop_loss, "tp": take_profit,
-                "commission": commission_cost, "comment": comment
-            })
+            self._update_equity_and_margin()
+            self.trade_history.append({"event_type": "MARKET_ORDER_FILLED", "timestamp": timestamp_unix, "order_id": order_id, "position_id": position_id, "symbol": symbol, "side": side.value, "volume": volume, "fill_price": entry_price_final, "sl": stop_loss, "tp": take_profit, "commission": commission_cost, "comment": comment})
             print(f"SimBroker: {side.value} {volume} {symbol} @ {entry_price_final} (spread/slip incl). PosID: {position_id}. Comm: {commission_cost:.2f}")
-
-            return OrderResponse(
-                order_id=order_id, status="FILLED", symbol=symbol, side=side, type=order_type,
-                volume=volume, price=entry_price_final, timestamp=timestamp_unix, error_message=None,
-                position_id=position_id
-            )
+            return OrderResponse(order_id=order_id, status="FILLED", symbol=symbol, side=side, type=order_type, volume=volume, price=entry_price_final, timestamp=timestamp_unix, error_message=None, position_id=position_id)
 
         elif order_type in [OrderType.LIMIT, OrderType.STOP]:
-            if price is None:
-                return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Price required for pending orders.")
-
-            # Inside place_order method
-            elif order_type in [OrderType.LIMIT, OrderType.STOP]:
-                if price is None:
-                    return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Price required for pending orders.")
-
-                # Store comprehensive details including SL/TP in self.pending_orders
-                self.pending_orders[order_id] = {
-                    "order_id": order_id,
-                    "status": "PENDING", # This is the status of the order itself
-                    "symbol": symbol,
-                    "side": side, # OrderSide Enum
-                    "type": order_type, # OrderType Enum
-                    "volume": volume,
-                    "price": price, # Activation price
-                    "timestamp": timestamp_unix, # Placement time
-                    "stop_loss": stop_loss, # SL for the future position
-                    "take_profit": take_profit, # TP for the future position
-                    "magic_number": magic_number, # Store these too
-                    "comment": comment
-                    # error_message is not typically part of the stored pending order, but for the response
-                }
-
-                self.trade_history.append({
-                    "event_type": "PENDING_ORDER_PLACED",
-                    "timestamp": timestamp_unix,
-                    "order_id": order_id,
-                    "symbol": symbol,
-                    "side": side.value, # Log enum value
-                    "type": order_type.value, # Log enum value
-                    "volume": volume,
-                    "price": price,
-                    "sl": stop_loss,
-                    "tp": take_profit,
-                    "comment": comment
-                })
-                print(f"SimBroker: Pending {side.value} {order_type.value} for {volume} {symbol} @ {price} SL:{stop_loss} TP:{take_profit} placed. OrderID: {order_id}")
-
-                # Return standard OrderResponse (which may not have SL/TP fields)
-                return OrderResponse(
-                    order_id=order_id, status="PENDING", symbol=symbol, side=side, type=order_type,
-                    volume=volume, price=price, timestamp=timestamp_unix, error_message=None
-                )
-
-        return OrderResponse(order_id=order_id, status="REJECTED", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message="Unsupported order type in place_order.")
+            if price is None: return OrderResponse(order_id=order_id, status="REJECTED", error_message="Price required for pending orders.")
+            self.pending_orders[order_id] = {"order_id": order_id, "status": "PENDING", "symbol": symbol, "side": side, "type": order_type, "volume": volume, "price": price, "timestamp": timestamp_unix, "stop_loss": stop_loss, "take_profit": take_profit, "magic_number": magic_number, "comment": comment}
+            self.trade_history.append({"event_type": "PENDING_ORDER_PLACED", "timestamp": timestamp_unix, "order_id": order_id, "symbol": symbol, "side": side.value, "type": order_type.value, "volume": volume, "price": price, "sl": stop_loss, "tp": take_profit, "comment": comment})
+            print(f"SimBroker: Pending {side.value} {order_type.value} for {volume} {symbol} @ {price} SL:{stop_loss} TP:{take_profit} placed. OrderID: {order_id}")
+            return OrderResponse(order_id=order_id, status="PENDING", symbol=symbol, side=side, type=order_type, volume=volume, price=price, timestamp=timestamp_unix, error_message=None)
+        return OrderResponse(order_id=order_id, status="REJECTED", error_message="Unsupported order type.")
 
     def process_pending_orders(self):
-        # Checks all pending orders against the current bar for trigger conditions.
-        if not self.current_market_data or not self.current_simulated_time_unix:
-            print("SimBroker.process_pending_orders: Market data or time not set.")
-            return
-
+        if not self.current_market_data or not self.current_simulated_time_unix: return
         orders_to_remove_after_processing = []
-
-        for order_id, pending_order_details in list(self.pending_orders.items()):
-            symbol = pending_order_details['symbol']
-            if symbol not in self.current_market_data or not self.current_market_data[symbol]:
-                continue
-
-            bar = self.current_market_data[symbol]
-            order_price = pending_order_details['price']
-            order_type: OrderType = pending_order_details['type']
-            order_side: OrderSide = pending_order_details['side']
-            order_volume = pending_order_details['volume']
-
-            # Retrieve SL/TP, magic, comment from the stored pending order details
-            sl_for_position = pending_order_details.get('stop_loss')
-            tp_for_position = pending_order_details.get('take_profit')
-            magic_for_position = pending_order_details.get('magic_number')
-            comment_for_position = pending_order_details.get('comment', f"Filled from pending {order_id}")
-
-            fill_price_simulated: Optional[float] = None
-            price_precision = self._get_price_precision(symbol)
-
+        for order_id, po_details in list(self.pending_orders.items()):
+            symbol, bar, order_price, order_type, order_side, order_volume = po_details['symbol'], self.current_market_data.get(po_details['symbol']), po_details['price'], po_details['type'], po_details['side'], po_details['volume']
+            if not bar: continue
+            sl_pos, tp_pos, magic_pos, comment_pos = po_details.get('stop_loss'), po_details.get('take_profit'), po_details.get('magic_number'), po_details.get('comment', f"Filled from pending {order_id}")
+            fill_price_sim: Optional[float] = None; precision = self._get_price_precision(symbol)
             if order_type == OrderType.LIMIT:
-                if order_side == OrderSide.BUY and bar['low'] <= order_price:
-                    fill_price_simulated = min(order_price, bar['open'])
-                elif order_side == OrderSide.SELL and bar['high'] >= order_price:
-                    fill_price_simulated = max(order_price, bar['open'])
-
+                if order_side == OrderSide.BUY and bar['low'] <= order_price: fill_price_sim = min(order_price, bar['open'])
+                elif order_side == OrderSide.SELL and bar['high'] >= order_price: fill_price_sim = max(order_price, bar['open'])
             elif order_type == OrderType.STOP:
-                if order_side == OrderSide.BUY and bar['high'] >= order_price:
-                    fill_price_simulated = max(order_price, bar['open'])
-                elif order_side == OrderSide.SELL and bar['low'] <= order_price:
-                    fill_price_simulated = min(order_price, bar['open'])
-
-            if fill_price_simulated is not None:
-                fill_price_simulated = round(fill_price_simulated, price_precision)
-                print(f"SimBroker: Pending order {order_id} ({symbol} {order_side.value} {order_type.value} @ {order_price}) TRIGGERED at simulated price {fill_price_simulated}.")
-
-                timestamp_unix = self.current_simulated_time_unix
-
-                # Apply slippage to the trigger price for the actual fill
-                actual_fill_price = fill_price_simulated
-                slippage_amount = self.fixed_slippage_pips * self._get_point_size(symbol)
-                if order_type == OrderType.STOP: # Stop orders are prone to slippage
-                    if order_side == OrderSide.BUY: actual_fill_price += random.uniform(0, slippage_amount)
-                    else: actual_fill_price -= random.uniform(0, slippage_amount)
-                actual_fill_price = round(actual_fill_price, price_precision)
-
-
-                margin_for_this_trade = self._calculate_margin_required(symbol, order_volume, actual_fill_price)
-                # Use a temporary get_account_info call to get current free margin
-                # This is not ideal as get_account_info might call _update_equity_and_margin
-                # A better way is to directly access self.equity and self.margin_used
+                if order_side == OrderSide.BUY and bar['high'] >= order_price: fill_price_sim = max(order_price, bar['open'])
+                elif order_side == OrderSide.SELL and bar['low'] <= order_price: fill_price_sim = min(order_price, bar['open'])
+            if fill_price_sim is not None:
+                fill_price_sim = round(fill_price_sim, precision); print(f"SimBroker: Pending order {order_id} TRIGGERED @ {fill_price_sim}.")
+                ts_unix = self.current_simulated_time_unix; actual_fill = fill_price_sim
+                slip_amt = self.fixed_slippage_pips * self._get_point_size(symbol)
+                if order_type == OrderType.STOP: actual_fill += random.uniform(0, slip_amt) if order_side == OrderSide.BUY else -random.uniform(0, slip_amt)
+                actual_fill = round(actual_fill, precision)
+                margin_req = self._calculate_margin_required(symbol, order_volume, actual_fill)
+                self._update_equity_and_margin() # Ensure fresh equity/margin for check
                 free_margin = self.equity - self.margin_used
-                if free_margin < margin_for_this_trade:
-                    print(f"SimBroker: Insufficient margin to fill pending order {order_id}. Need: {margin_for_this_trade:.2f}, Have: {free_margin:.2f}. Order removed.")
-                    self.trade_history.append({
-                        "event_type": "PENDING_ORDER_FAIL_MARGIN", "timestamp": timestamp_unix,
-                        "order_id": order_id, "symbol": symbol, "side": order_side.value, "volume": order_volume,
-                        "trigger_price": fill_price_simulated, "reason": "Insufficient margin"
-                    })
-                    orders_to_remove_after_processing.append(order_id)
-                    continue
-
-                commission = self._calculate_commission(symbol, order_volume)
-
-                position_id = self._generate_unique_id()
-                new_position = Position(
-                    position_id=position_id, symbol=symbol, side=order_side, volume=order_volume,
-                    entry_price=actual_fill_price,
-                    current_price=actual_fill_price,
-                    profit_loss= -commission,
-                    stop_loss=sl_for_position,
-                    take_profit=tp_for_position,
-                    open_time=timestamp_unix,
-                    magic_number=magic_for_position,
-                    comment=comment_for_position
-                )
-                self.open_positions[position_id] = new_position
-
-                self.balance -= commission
-                self.margin_used += margin_for_this_trade
-
-                self.trade_history.append({
-                    "event_type": "PENDING_ORDER_FILLED", "timestamp": timestamp_unix,
-                    "original_order_id": order_id, "position_id": position_id, "symbol": symbol,
-                    "side": order_side.value, "type": order_type.value, "volume": order_volume,
-                    "requested_price": order_price, "fill_price": actual_fill_price,
-                    "sl": sl_for_position, "tp": tp_for_position, "commission": commission,
-                    "comment": comment_for_position
-                })
-                print(f"SimBroker: Pending order {order_id} FILLED. New PosID: {position_id} for {symbol} {order_side.value} {order_volume} @ {actual_fill_price}. Comm: {commission:.2f}")
-
+                if free_margin < margin_req:
+                    print(f"SimBroker: Insufficient margin for pending {order_id}. Need: {margin_req:.2f}, Have: {free_margin:.2f}. Removed.")
+                    self.trade_history.append({"event_type": "PENDING_ORDER_FAIL_MARGIN", "timestamp": ts_unix, "order_id": order_id, "symbol": symbol, "side": order_side.value, "volume": order_volume, "trigger_price": fill_price_sim, "reason": "Insufficient margin"})
+                    orders_to_remove_after_processing.append(order_id); continue
+                commission = self._calculate_commission(symbol, order_volume); pos_id = self._generate_unique_id()
+                new_pos = Position(position_id=pos_id, symbol=symbol, side=order_side, volume=order_volume, entry_price=actual_fill, current_price=actual_fill, profit_loss= -commission, stop_loss=sl_pos, take_profit=tp_pos, open_time=ts_unix, magic_number=magic_pos, comment=comment_pos)
+                self.open_positions[pos_id] = new_pos; self.balance -= commission; self.margin_used += margin_req
+                self._update_equity_and_margin()
+                self.trade_history.append({"event_type": "PENDING_ORDER_FILLED", "timestamp": ts_unix, "original_order_id": order_id, "position_id": pos_id, "symbol": symbol, "side": order_side.value, "type": order_type.value, "volume": order_volume, "requested_price": order_price, "fill_price": actual_fill, "sl": sl_pos, "tp": tp_pos, "commission": commission, "comment": comment_pos})
+                print(f"SimBroker: Pending order {order_id} FILLED. New PosID: {pos_id} for {symbol} {order_side.value} {order_volume} @ {actual_fill}. Comm: {commission:.2f}")
                 orders_to_remove_after_processing.append(order_id)
-
-        for order_id_to_remove in orders_to_remove_after_processing:
-            if order_id_to_remove in self.pending_orders:
-                del self.pending_orders[order_id_to_remove]
-
-        # Call _update_equity_and_margin() once after all bar events are processed by backtester main loop
-        # self._update_equity_and_margin() # Not here, but in main loop after this and SL/TP checks
+        for oid in orders_to_remove_after_processing:
+            if oid in self.pending_orders: del self.pending_orders[oid]
 
     def _update_equity_and_margin(self):
-        current_total_pnl = 0.0
-        current_total_margin_used = 0.0 # Recalculate margin used based on open positions
-        contract_size = 100000
+        current_total_unrealized_pnl = 0.0
+        current_total_margin_used = 0.0
+        # contract_size = 100000 # Already part of calculate_pnl_in_account_currency
 
-        positions_to_remove = []
+        for pos_id, pos_dict_or_obj in list(self.open_positions.items()): # Iterate on list copy if modifications happen
+            # Ensure we're working with a consistent object type, prefer dict for direct updates here
+            # If Position objects are stored, they need to be mutable or replaced.
+            # Assuming self.open_positions stores dictionaries that conform to Position TypedDict.
+            current_pos_data = pos_dict_or_obj
 
-        for pos_id, pos_dict in self.open_positions.items():
-            # Convert dict to Position TypedDict for safety if necessary, or ensure it's always stored as TypedDict
-            pos = Position(**pos_dict) if isinstance(pos_dict, dict) else pos_dict
-
-            current_bar = self.current_market_data.get(pos.symbol)
-            if not current_bar:
-                # If no current market data for an open position's symbol, P/L cannot be updated accurately.
-                # Keep its last known P/L or handle as error/stale data.
-                # For now, just add its last known P/L.
-                current_total_pnl += pos.profit_loss
-                current_total_margin_used += self._calculate_margin_required(pos.symbol, pos.volume, pos.entry_price) # Margin is on entry
+            symbol_info = self._get_symbol_info(current_pos_data['symbol'])
+            if not symbol_info:
+                print(f"SimBroker._update_equity_and_margin: Missing symbol info for {current_pos_data['symbol']}, cannot update P/L accurately.")
+                # Add existing P/L if available, otherwise 0 for this position.
+                current_total_unrealized_pnl += current_pos_data.get('profit_loss', 0.0)
+                # Recalculate margin based on entry price, even if P/L cannot be updated.
+                current_total_margin_used += self._calculate_margin_required(current_pos_data['symbol'], current_pos_data['volume'], current_pos_data['entry_price'])
                 continue
 
-            market_price_for_pnl = current_bar['close'] # Use close for P/L calculation
-            spread_amount = self._get_spread_in_price_terms(pos.symbol)
+            current_bar = self.current_market_data.get(current_pos_data['symbol'])
+            if not current_bar:
+                # print(f"SimBroker._update_equity_and_margin: No current market data for {current_pos_data['symbol']}. P/L for pos {pos_id} not updated this tick.")
+                # Add existing P/L as it couldn't be updated
+                current_total_unrealized_pnl += current_pos_data.get('profit_loss', 0.0)
+                current_total_margin_used += self._calculate_margin_required(current_pos_data['symbol'], current_pos_data['volume'], current_pos_data['entry_price'])
+                continue
 
-            price_diff = 0.0
-            current_exit_price_for_pos: float
-            if pos.side == OrderSide.BUY:
-                current_exit_price_for_pos = market_price_for_pnl - (spread_amount / 2) # Current Bid
-                price_diff = current_exit_price_for_pos - pos.entry_price
-            else: # SELL
-                current_exit_price_for_pos = market_price_for_pnl + (spread_amount / 2) # Current Ask
-                price_diff = pos.entry_price - current_exit_price_for_pos
+            market_close_price = current_bar['close']
+            spread_amount_for_symbol = self._get_spread_in_price_terms(current_pos_data['symbol'])
+            price_precision = symbol_info['price_precision']
 
-            # P/L calculation needs to be accurate.
-            # Simplified: (price_difference / point_size) * pip_value_in_account_currency * volume_in_lots * points_per_pip
-            # Or (price_difference * contract_size_units * volume_in_lots) * (conversion_to_account_currency)
-            # The prompt used: price_diff * pos.volume * contract_size. This assumes quote currency = account currency.
-            pos_pnl_no_commission = price_diff * pos.volume * contract_size
+            valuation_price: float
+            if current_pos_data['side'] == OrderSide.BUY: # Long position, valued at current Bid
+                valuation_price = round(market_close_price - (spread_amount_for_symbol / 2), price_precision)
+            else: # SELL position, valued at current Ask
+                valuation_price = round(market_close_price + (spread_amount_for_symbol / 2), price_precision)
 
-            # Commission was already deducted from balance. P/L should reflect market movement.
-            # So, the 'profit_loss' field in Position should be market_pnl.
-            # The initial -commission in profit_loss was to reflect immediate equity change.
-            # When updating, we calculate fresh market P/L. The "total P/L" for equity is this market P/L.
-            # Commission is a one-off hit to balance.
+            unrealized_pnl_for_pos = self.calculate_pnl_in_account_currency(
+                current_pos_data['symbol'],
+                current_pos_data['side'],
+                current_pos_data['volume'],
+                current_pos_data['entry_price'],
+                valuation_price
+            )
 
-            self.open_positions[pos_id]['profit_loss'] = pos_pnl_no_commission # Market P/L
-            self.open_positions[pos_id]['current_price'] = current_exit_price_for_pos # Reflects realistic exit
-            current_total_pnl += pos_pnl_no_commission
+            if unrealized_pnl_for_pos is not None:
+                self.open_positions[pos_id]['profit_loss'] = unrealized_pnl_for_pos
+                self.open_positions[pos_id]['current_price'] = valuation_price
+                current_total_unrealized_pnl += unrealized_pnl_for_pos
+            else:
+                # If PNL calculation failed (e.g. missing exchange rate), add last known PNL
+                print(f"SimBroker._update_equity_and_margin: PNL calculation failed for {current_pos_data['symbol']} pos {pos_id}. Using last known PNL.")
+                current_total_unrealized_pnl += current_pos_data.get('profit_loss', 0.0)
 
-            # Margin for this position (recalculate, though usually fixed at entry unless rules change)
-            current_total_margin_used += self._calculate_margin_required(pos.symbol, pos.volume, pos.entry_price)
+            # Margin is based on entry price, not current price
+            margin_for_pos = self._calculate_margin_required(current_pos_data['symbol'], current_pos_data['volume'], current_pos_data['entry_price'])
+            current_total_margin_used += margin_for_pos
 
-        self.equity = self.balance + current_total_pnl
+        self.equity = self.balance + current_total_unrealized_pnl
         self.margin_used = current_total_margin_used
-        # print(f"SimBroker: Equity updated. Balance: {self.balance:.2f}, Total P/L: {current_total_pnl:.2f}, Equity: {self.equity:.2f}, Margin Used: {self.margin_used:.2f}")
+        # print(f"SimBroker: Equity updated. Balance: {self.balance:.2f}, Total Unrealized P/L: {current_total_unrealized_pnl:.2f}, Equity: {self.equity:.2f}, Margin Used: {self.margin_used:.2f}")
 
-
-    def modify_order(self, order_id: str, new_price: Optional[float] = None,
-                       new_stop_loss: Optional[float] = None, new_take_profit: Optional[float] = None) -> OrderResponse:
-        print(f"SimulatedBroker: modify_order({order_id}) called. SL:{new_stop_loss} TP:{new_take_profit}")
+    def modify_order(self, order_id: str, new_price: Optional[float] = None, new_stop_loss: Optional[float] = None, new_take_profit: Optional[float] = None) -> OrderResponse:
+        ts = self.current_simulated_time_unix
         if order_id in self.open_positions:
             pos = self.open_positions[order_id]
             if new_stop_loss is not None: pos['stop_loss'] = new_stop_loss
             if new_take_profit is not None: pos['take_profit'] = new_take_profit
-            self.open_positions[order_id] = pos # Update the position dict
-            return OrderResponse(order_id=order_id, status="MODIFIED", symbol=pos['symbol'], side=pos['side'], type=OrderType.MARKET, volume=pos['volume'], price=pos['entry_price'], timestamp=self.current_simulated_time_unix, position_id=order_id)
+            return OrderResponse(order_id=order_id, status="MODIFIED", symbol=pos['symbol'], side=pos['side'], type=OrderType.MARKET, volume=pos['volume'], price=pos['entry_price'], timestamp=ts, position_id=order_id)
         elif order_id in self.pending_orders:
-            # Logic for modifying pending orders (not fully implemented in this step)
-            # self.pending_orders[order_id]['stop_loss'] = new_stop_loss ...
-            return OrderResponse(order_id=order_id, status="MODIFIED_PENDING", symbol=self.pending_orders[order_id]['symbol'], side=self.pending_orders[order_id]['side'], type=self.pending_orders[order_id]['type'], volume=self.pending_orders[order_id]['volume'], price=self.pending_orders[order_id]['price'], timestamp=self.current_simulated_time_unix)
-        return OrderResponse(order_id=order_id, status="REJECTED", error_message="Order/Position not found for modification.")
+            po = self.pending_orders[order_id]
+            if new_price is not None: po['price'] = new_price
+            if new_stop_loss is not None: po['stop_loss'] = new_stop_loss
+            if new_take_profit is not None: po['take_profit'] = new_take_profit
+            return OrderResponse(order_id=order_id, status="MODIFIED_PENDING", symbol=po['symbol'], side=po['side'], type=po['type'], volume=po['volume'], price=po['price'], timestamp=ts)
+        return OrderResponse(order_id=order_id, status="REJECTED", error_message="Order/Position not found.", timestamp=ts)
 
-    def close_order(self, order_id: str, volume: Optional[float] = None, price: Optional[float] = None) -> OrderResponse:
-        print(f"SimulatedBroker: close_order({order_id}, vol={volume}) called.")
-        if order_id not in self.open_positions:
-            return OrderResponse(order_id=order_id, status="REJECTED", error_message="Position not found to close.")
-
-        pos_to_close_dict = self.open_positions[order_id]
-        pos_to_close = Position(**pos_to_close_dict) # Ensure TypedDict for access
-
-        # Use current market price for closing, including spread
-        current_bar = self.current_market_data.get(pos_to_close.symbol)
-        if not current_bar:
-            return OrderResponse(order_id=order_id, status="REJECTED", symbol=pos_to_close.symbol, error_message="Market data not available to close position.")
-
-        spread_amount = self._get_spread_in_price_terms(pos_to_close.symbol)
-        close_price_base = current_bar['close']
-
-        final_close_price: float
-        if pos_to_close.side == OrderSide.BUY: # Closing a BUY means SELLING
-            final_close_price = close_price_base - (spread_amount / 2) # Bid
-        else: # Closing a SELL means BUYING
-            final_close_price = close_price_base + (spread_amount / 2) # Ask
-
-        final_close_price = round(final_close_price, self._get_price_precision(pos_to_close.symbol))
-
-        # P/L calculation for the closed trade
-        price_diff = 0.0
-        if pos_to_close.side == OrderSide.BUY:
-            price_diff = final_close_price - pos_to_close.entry_price
-        else: # SELL
-            price_diff = pos_to_close.entry_price - final_close_price
-
-        # P/L = price_diff * volume_units. Assuming volume is in lots.
-        contract_size = 100000
-        realized_pnl = price_diff * pos_to_close.volume * contract_size # Simplified, assumes quote currency = account currency
-
-        # Update account: balance reflects realized P/L. Margin for this trade is freed.
-        self.balance += realized_pnl # Commission was already paid from balance at open.
-        self.margin_used -= self._calculate_margin_required(pos_to_close.symbol, pos_to_close.volume, pos_to_close.entry_price)
-
-        del self.open_positions[order_id]
-        self._update_equity_and_margin() # Update overall equity and margin
-
-        self.trade_history.append({
-            "event_type": "POSITION_CLOSED", "timestamp": self.current_simulated_time_unix,
-            "position_id": order_id, "symbol": pos_to_close.symbol, "side": pos_to_close.side.value,
-            "volume": pos_to_close.volume, "entry_price": pos_to_close.entry_price, "close_price": final_close_price,
-            "realized_pnl": realized_pnl, "comment": "Position closed by request."
-        })
-        print(f"SimBroker: Position {order_id} ({pos_to_close.symbol}) closed @ {final_close_price}. Realized P/L: {realized_pnl:.2f}")
-
-        return OrderResponse(
-            order_id=order_id, # Original order_id that opened position, or position_id itself if different
-            status="CLOSED", symbol=pos_to_close.symbol, side=pos_to_close.side, type=OrderType.MARKET, # Type of closing order
-            volume=pos_to_close.volume, price=final_close_price, timestamp=self.current_simulated_time_unix,
-            position_id=order_id, # Redundant if order_id is same as pos_id
-            error_message=None
-        )
-
-    def get_open_positions(self, symbol: Optional[str] = None) -> List[Position]:
-        # print(f"SimulatedBroker: get_open_positions({symbol if symbol else 'all'}) called.")
-        self._update_equity_and_margin() # Ensure P/L is current
-        positions = []
-        for pos_data in self.open_positions.values():
-            # Ensure it's a TypedDict before appending
-            pos = Position(**pos_data) if isinstance(pos_data, dict) else pos_data
-            if symbol is None or pos.symbol == symbol:
-                positions.append(pos)
-        return positions
-
-    def get_pending_orders(self, symbol: Optional[str] = None) -> List[OrderResponse]:
-        # print(f"SimulatedBroker: get_pending_orders({symbol if symbol else 'all'}) called.")
-        orders = []
-        for order_data in self.pending_orders.values():
-            order = OrderResponse(**order_data) if isinstance(order_data, dict) else order_data
-            if symbol is None or order.symbol == symbol:
-                orders.append(order)
-        return orders
-
-    # Add this new method
-    def check_for_sl_tp_triggers(self):
-        # Checks all open positions against the current bar's data for SL/TP triggers.
-        # This should be called by the backtester event loop for each new bar
-        # BEFORE the strategy/agents generate new signals for that bar.
-        if not self.current_market_data or not self.current_simulated_time_unix:
-            print("SimBroker.check_for_sl_tp_triggers: Market data or time not set.")
-            return
-
-        positions_to_action = []
-
-        for pos_id, pos_data in list(self.open_positions.items()): # Iterate on list copy for safe modification
-            # Ensure pos is a Position TypedDict instance for type safety if it's stored as dict
-            pos = Position(**pos_data) if isinstance(pos_data, dict) else pos_data
-
-            if pos.symbol not in self.current_market_data or not self.current_market_data[pos.symbol]:
-                # print(f"SimBroker.check_for_sl_tp_triggers: No current market data for symbol {pos.symbol} of position {pos_id}")
-                continue
-
-            bar = self.current_market_data[pos.symbol]
-            trigger_price = None
-            reason_for_close = None
-
-            if pos.side == OrderSide.BUY:
-                if pos.stop_loss is not None and bar['low'] <= pos.stop_loss:
-                    trigger_price = pos.stop_loss
-                    reason_for_close = "STOP_LOSS_HIT"
-                elif pos.take_profit is not None and bar['high'] >= pos.take_profit:
-                    trigger_price = pos.take_profit
-                    reason_for_close = "TAKE_PROFIT_HIT"
-
-            elif pos.side == OrderSide.SELL:
-                if pos.stop_loss is not None and bar['high'] >= pos.stop_loss:
-                    trigger_price = pos.stop_loss
-                    reason_for_close = "STOP_LOSS_HIT"
-                elif pos.take_profit is not None and bar['low'] <= pos.take_profit:
-                    trigger_price = pos.take_profit
-                    reason_for_close = "TAKE_PROFIT_HIT"
-
-            if trigger_price is not None and reason_for_close is not None:
-                positions_to_action.append({
-                    "position_id": pos_id, # Keep original pos_id for reference
-                    "position_to_close": pos,
-                    "close_price": trigger_price,
-                    "reason": reason_for_close
-                })
-
-        for action_item in positions_to_action:
-            # Pass the actual Position object, not just its ID
-            self._close_position_at_price(
-                position=action_item["position_to_close"],
-                close_price=action_item["close_price"],
-                reason=action_item["reason"]
-            )
-
-    # Add this new internal helper method
     def _close_position_at_price(self, position: Position, close_price: float, reason: str):
-        # Ensure position_id is correctly accessed from the Position TypedDict
         current_position_id = position.position_id
-
         if current_position_id not in self.open_positions:
             print(f"SimBroker: Position {current_position_id} already actioned or does not exist. Cannot close for reason: {reason}.")
             return
 
-        contract_size = 100000
-        price_diff = 0.0
+        realized_pnl = self.calculate_pnl_in_account_currency(position.symbol, position.side, position.volume, position.entry_price, close_price)
 
-        # Assuming SL/TP orders execute AT these prices without further spread/slippage for this sim level.
-        if position.side == OrderSide.BUY:
-            price_diff = close_price - position.entry_price
-        elif position.side == OrderSide.SELL:
-            price_diff = position.entry_price - close_price
-
-        # Placeholder P/L - requires robust pip/point value calculation based on pair and account currency
-        realized_pnl = price_diff * position.volume * contract_size
+        if realized_pnl is None:
+            print(f"SimBroker: PNL calculation failed for closing pos {current_position_id} ({position.symbol}). Realized PNL recorded as 0.0. Position will still be closed.")
+            realized_pnl = 0.0 # Set PNL to 0.0 for accounting if calculation failed, but still close position
 
         self.balance += realized_pnl
-
-        # Ensure Position TypedDict has 'open_time' and optionally 'comment'
-        # Safely access using .get() for fields that might be missing from some Position dicts if not strictly enforced
-        open_time_for_log = position.get('open_time', self.current_simulated_time_unix)
-        comment_for_log = position.get('comment', "")
-        magic_number_for_log = position.get('magic_number', 0)
-
-
-        self.trade_history.append({
-            "event_type": "POSITION_CLOSED",
-            "timestamp": self.current_simulated_time_unix,
-            "position_id": current_position_id,
-            "symbol": position.symbol,
-            "side": position.side.value,
-            "volume": position.volume,
-            "entry_price": position.entry_price,
-            "open_time": open_time_for_log,
-            "close_price": close_price,
-            "realized_pnl": realized_pnl,
-            "reason_for_close": reason,
-            "magic_number": magic_number_for_log,
-            "comment": comment_for_log
-        })
-
-        # Margin for this position is now freed
         margin_freed = self._calculate_margin_required(position.symbol, position.volume, position.entry_price)
         self.margin_used -= margin_freed
-        if self.margin_used < 0: self.margin_used = 0 # Prevent negative margin
+        if self.margin_used < 0: self.margin_used = 0
 
-        removed_pos_dict = self.open_positions.pop(current_position_id, None)
+        open_time_log = position.get('open_time', self.current_simulated_time_unix)
+        comment_log = position.get('comment', "")
+        magic_log = position.get('magic_number', 0)
 
-        if removed_pos_dict:
-            print(f"SimBroker: Position {current_position_id} ({position.symbol} {position.side.value} {position.volume} lot(s)) CLOSED at {close_price} by {reason}. P/L: {realized_pnl:.2f}. Margin Freed: {margin_freed:.2f}")
-            self._update_equity_and_margin()
-        else:
-            # This case should ideally not be hit if logic is correct, as we check current_position_id in self.open_positions
-            print(f"SimBroker Warning: Tried to log/update for position {current_position_id} but it was not found in open_positions after pop attempt.")
+        self.trade_history.append({"event_type": "POSITION_CLOSED", "timestamp": self.current_simulated_time_unix, "position_id": current_position_id, "symbol": position.symbol, "side": position.side.value, "volume": position.volume, "entry_price": position.entry_price, "open_time": open_time_log, "close_price": close_price, "realized_pnl": realized_pnl, "reason_for_close": reason, "magic_number": magic_log, "comment": comment_log})
+
+        del self.open_positions[current_position_id]
+        print(f"SimBroker: Position {current_position_id} ({position.symbol} {position.side.value} {position.volume} lot(s)) CLOSED at {close_price} by {reason}. P/L: {realized_pnl:.2f}. Margin Freed: {margin_freed:.2f}")
+        self._update_equity_and_margin()
+
+    def check_for_sl_tp_triggers(self):
+        if not self.current_market_data or not self.current_simulated_time_unix: return
+        positions_to_action = []
+        for pos_id, pos_data in list(self.open_positions.items()):
+            pos = Position(**pos_data) if isinstance(pos_data, dict) else pos_data
+            if pos.symbol not in self.current_market_data: continue
+            bar = self.current_market_data[pos.symbol]
+            trigger_price = None; reason = None
+            if pos.side == OrderSide.BUY:
+                if pos.stop_loss is not None and bar['low'] <= pos.stop_loss: trigger_price, reason = pos.stop_loss, "STOP_LOSS_HIT"
+                elif pos.take_profit is not None and bar['high'] >= pos.take_profit: trigger_price, reason = pos.take_profit, "TAKE_PROFIT_HIT"
+            elif pos.side == OrderSide.SELL:
+                if pos.stop_loss is not None and bar['high'] >= pos.stop_loss: trigger_price, reason = pos.stop_loss, "STOP_LOSS_HIT"
+                elif pos.take_profit is not None and bar['low'] <= pos.take_profit: trigger_price, reason = pos.take_profit, "TAKE_PROFIT_HIT"
+            if trigger_price is not None: positions_to_action.append({"position_to_close": pos, "close_price": trigger_price, "reason": reason})
+        for item in positions_to_action: self._close_position_at_price(item["position_to_close"], item["close_price"], item["reason"])
+
+    def close_order(self, order_id: str, volume: Optional[float] = None, price: Optional[float] = None) -> OrderResponse: # order_id here is position_id
+        if order_id not in self.open_positions: return OrderResponse(order_id=order_id, status="REJECTED", error_message="Position not found.")
+        pos_to_close = Position(**self.open_positions[order_id]) if isinstance(self.open_positions[order_id], dict) else self.open_positions[order_id]
+        current_bar = self.current_market_data.get(pos_to_close.symbol)
+        if not current_bar: return OrderResponse(order_id=order_id, status="REJECTED", error_message="Market data unavailable.")
+
+        close_price_to_use = price
+        if close_price_to_use is None: # Market close
+            spread_amount = self._get_spread_in_price_terms(pos_to_close.symbol)
+            close_price_base = current_bar['close']
+            close_price_to_use = (close_price_base - spread_amount / 2) if pos_to_close.side == OrderSide.BUY else (close_price_base + spread_amount / 2)
+            close_price_to_use = round(close_price_to_use, self._get_price_precision(pos_to_close.symbol))
+
+        # Volume check not implemented for partial close, assuming full close
+        self._close_position_at_price(pos_to_close, close_price_to_use, "CLOSED_BY_REQUEST")
+        return OrderResponse(order_id=order_id, status="CLOSED", symbol=pos_to_close.symbol, side=pos_to_close.side, type=OrderType.MARKET, volume=pos_to_close.volume, price=close_price_to_use, timestamp=self.current_simulated_time_unix, position_id=order_id)
+
+    def get_open_positions(self, symbol: Optional[str] = None) -> List[Position]:
+        self._update_equity_and_margin()
+        return [Position(**pos_data) if isinstance(pos_data, dict) else pos_data for pos_data in self.open_positions.values() if symbol is None or pos_data['symbol'] == symbol]
+
+    def get_pending_orders(self, symbol: Optional[str] = None) -> List[OrderResponse]:
+        return [OrderResponse(**order_data) for order_data in self.pending_orders.values() if symbol is None or order_data['symbol'] == symbol]
+
+    def check_for_margin_call(self):
+        # This method checks if the account's margin level has fallen below critical thresholds.
+        # If below stop-out level, it force-liquidates positions.
+        # It should be called by the backtester event loop AFTER all P/L for open positions
+        # has been updated for the current bar (i.e., after _update_equity_and_margin).
+
+        if self.margin_used == 0: # No margin used, so no margin call possible
+            return
+
+        # _update_equity_and_margin should have been called before this to ensure self.equity is current.
+        margin_level_pct = (self.equity / self.margin_used) * 100 if self.margin_used > 0 else float('inf')
+
+        timestamp_unix = self.current_simulated_time_unix
+        log_event_common = {
+            "timestamp": timestamp_unix,
+            "equity": self.equity,
+            "margin_used": self.margin_used,
+            "margin_level_pct": margin_level_pct,
+        }
+
+        if margin_level_pct <= self.stop_out_level_pct:
+            print(f"SimBroker: MARGIN CALL (STOP OUT)! Margin Level: {margin_level_pct:.2f}% <= Stop Out Level: {self.stop_out_level_pct:.2f}%. Force liquidating positions.")
+            self.trade_history.append({
+                **log_event_common,
+                "event_type": "MARGIN_CALL_STOP_OUT_TRIGGERED",
+            })
+
+            # Liquidate positions starting with the one with the largest loss
+            while self.margin_used > 0 and ((self.equity / self.margin_used * 100) if self.margin_used > 0 else float('inf')) <= self.stop_out_level_pct:
+                if not self.open_positions:
+                    break # No positions left to liquidate
+
+                worst_pos_id = None
+                largest_loss = float('inf') # Using float('inf') ensures any loss is smaller
+
+                for pos_id, pos_data in self.open_positions.items():
+                    # Ensure pos_data is treated as a dict for .get, or use Position attributes
+                    current_pos_pnl = pos_data.get('profit_loss', 0.0)
+                    if current_pos_pnl < largest_loss:
+                        largest_loss = current_pos_pnl
+                        worst_pos_id = pos_id
+
+                if worst_pos_id:
+                    # Retrieve the full Position object/dict to pass to _close_position_at_price
+                    position_to_liquidate_data = self.open_positions[worst_pos_id]
+                    # Assuming Position TypedDict is used for type hints but underlying storage is dict
+                    # or that Position object itself is stored. For _close_position_at_price, it expects Position object.
+                    # If self.open_positions stores dicts, we need to cast it
+                    position_obj_to_liquidate = Position(**position_to_liquidate_data) if isinstance(position_to_liquidate_data, dict) else position_to_liquidate_data
+
+                    symbol_to_liquidate = position_obj_to_liquidate.symbol # Use attribute access
+
+                    print(f"SimBroker: Liquidating position {worst_pos_id} ({symbol_to_liquidate}) due to margin call. Current P/L: {largest_loss:.2f}")
+
+                    close_price_for_liquidation = None
+                    if symbol_to_liquidate in self.current_market_data and self.current_market_data[symbol_to_liquidate]:
+                        bar = self.current_market_data[symbol_to_liquidate]
+                        spread_amount = self._get_spread_in_price_terms(symbol_to_liquidate)
+                        price_precision = self._get_price_precision(symbol_to_liquidate)
+                        if position_obj_to_liquidate.side == OrderSide.BUY: # Closing a BUY by SELLING
+                            close_price_for_liquidation = round(bar['close'] - (spread_amount / 2), price_precision) # at Bid
+                        else: # Closing a SELL by BUYING
+                            close_price_for_liquidation = round(bar['close'] + (spread_amount / 2), price_precision) # at Ask
+
+                        self._close_position_at_price(position_obj_to_liquidate, close_price_for_liquidation, "MARGIN_CALL_LIQUIDATION")
+                    else:
+                        print(f"SimBroker ERROR: Market data unavailable for {symbol_to_liquidate} to liquidate {worst_pos_id}! Position remains for now (potential issue).")
+                        self.trade_history.append({
+                            "event_type": "MARGIN_CALL_LIQUIDATION_ERROR",
+                            "timestamp": timestamp_unix, "position_id": worst_pos_id,
+                            "reason": "Market data unavailable for liquidation price."})
+                        break
+                else:
+                    if not self.open_positions: break
+                    print("SimBroker: Margin call, but no clear 'worst loss' position or all profitable. Consider alternative liquidation order. Halting this cycle.")
+                    # Fallback: close the first available position if no "worst loss" is found among multiple positions
+                    if self.open_positions: # Check again if any positions are left
+                        first_pos_id = list(self.open_positions.keys())[0]
+                        position_to_liquidate_data = self.open_positions[first_pos_id]
+                        position_obj_to_liquidate = Position(**position_to_liquidate_data) if isinstance(position_to_liquidate_data, dict) else position_to_liquidate_data
+                        print(f"SimBroker: Fallback liquidation of position {first_pos_id} due to margin call.")
+                        symbol_to_liquidate = position_obj_to_liquidate.symbol
+                        if symbol_to_liquidate in self.current_market_data and self.current_market_data[symbol_to_liquidate]:
+                            bar = self.current_market_data[symbol_to_liquidate]
+                            spread_amount = self._get_spread_in_price_terms(symbol_to_liquidate)
+                            price_precision = self._get_price_precision(symbol_to_liquidate)
+                            if position_obj_to_liquidate.side == OrderSide.BUY:
+                                close_price_for_liquidation = round(bar['close'] - (spread_amount / 2), price_precision)
+                            else:
+                                close_price_for_liquidation = round(bar['close'] + (spread_amount / 2), price_precision)
+                            self._close_position_at_price(position_obj_to_liquidate, close_price_for_liquidation, "MARGIN_CALL_LIQUIDATION_FALLBACK")
+                        else:
+                            print(f"SimBroker ERROR: Market data also unavailable for fallback liquidation {first_pos_id}. Halting liquidation cycle.")
+                            break
+                    else: # Should be caught by the outer if not self.open_positions: break
+                        break
+
+                if self.margin_used == 0: break # All positions liquidated or margin freed sufficiently
+
+            current_margin_level_after_liquidation = (self.equity / self.margin_used * 100) if self.margin_used > 0 else float('inf')
+            if current_margin_level_after_liquidation > self.stop_out_level_pct:
+                 print(f"SimBroker: Margin level restored to {current_margin_level_after_liquidation:.2f}% after liquidations.")
+                 self.trade_history.append({
+                    "event_type": "MARGIN_CALL_RESOLVED", "timestamp": timestamp_unix,
+                    "final_margin_level_pct": current_margin_level_after_liquidation })
+            else:
+                 print(f"SimBroker: Margin level at {current_margin_level_after_liquidation:.2f}% after liquidation attempts. Stop out may not be fully resolved if margin_used is still high.")
+
+
+        elif margin_level_pct <= self.margin_call_warning_level_pct:
+            print(f"SimBroker: MARGIN WARNING! Margin Level: {margin_level_pct:.2f}% (Warning Level: {self.margin_call_warning_level_pct:.2f}%)")
+            self.trade_history.append({
+                **log_event_common,
+                "event_type": "MARGIN_WARNING_TRIGGERED",
+            })
 
 ```


### PR DESCRIPTION
… testing framework. This includes adding helper functions for broker setup and a bar-by-bar simulation loop (`run_simulation_loop`).

I've also introduced `SimulatedBroker.load_test_data()` to allow feeding specific market data sequences for controlled testing, and updated `get_historical_data` to prioritize this test data.

Additionally, I've implemented two initial test scenarios:
1. `test_scenario_winning_buy_tp()`: This verifies that a BUY market order correctly hits its Take Profit.
2. `test_scenario_losing_sell_sl()`: This verifies that a SELL market order correctly hits its Stop Loss.

These scenarios validate basic order execution, SL/TP triggering, P/L calculation, and trade history logging in SimulatedBroker.